### PR TITLE
Support encoding and decoding decimal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ doc
 *.sublime-*
 rebar3
 _build/
-
+tags

--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,7 @@
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [debug_info]}.
+{deps,
+ [
+  {decimal, {git, "https://github.com/emq-inc/erlang-decimal.git", {ref, "f4e2bcb"}}}
+ ]
+}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,4 @@
-[].
+[{<<"decimal">>,
+  {git,"https://github.com/emq-inc/erlang-decimal.git",
+       {ref,"f4e2bcbc6147081acfcfb7811c5a8ba92c8707ed"}},
+  0}].

--- a/src/jsx.erl
+++ b/src/jsx.erl
@@ -524,4 +524,24 @@ end_stream_test_() ->
     ].
 
 
+naked_decimals() ->
+    [{Title, JSON, decimal_conv:number(JSON), []}
+     || {Title, JSON, _Term, _Events} <- naked_floats()].
+
+
+decimals() ->
+    naked_decimals()
+    ++ [ wrap_with_array(Test) || Test <- naked_decimals() ]
+    ++ [ wrap_with_object(Test) || Test <- naked_decimals() ].
+
+
+decimal_test_() ->
+    Data = decimals(),
+    [{Title, ?_assertEqual(Term, decode(JSON, [decimal]))}
+     || {Title, JSON, Term, _Events} <- Data
+    ] ++
+    [{Title, ?_assertEqual(JSON, encode(Term))}
+     || {Title, JSON, Term, _Events} <- Data
+    ].
+
 -endif.

--- a/src/jsx_config.erl
+++ b/src/jsx_config.erl
@@ -85,6 +85,8 @@ parse_config([{strict, Strict}|Rest], Config) ->
     parse_strict(Strict, Rest, Config);
 parse_config([stream|Rest], Config) ->
     parse_config(Rest, Config#config{stream=true});
+parse_config([decimal|Rest], Config) ->
+    parse_config(Rest, Config#config{decimal=true});
 parse_config([{error_handler, ErrorHandler}|Rest] = Options, Config) when is_function(ErrorHandler, 3) ->
     case Config#config.error_handler of
         false -> parse_config(Rest, Config#config{error_handler=ErrorHandler})
@@ -166,6 +168,7 @@ valid_flags() ->
         repeat_keys,
         strict,
         stream,
+        decimal,
         uescape,
         error_handler,
         incomplete_handler

--- a/src/jsx_config.hrl
+++ b/src/jsx_config.hrl
@@ -10,6 +10,7 @@
     strict_escapes = false              :: boolean(),
     strict_control_codes = false        :: boolean(),
     stream = false                      :: boolean(),
+    decimal = false                     :: boolean(),
     return_tail = false                 :: boolean(),
     uescape = false                     :: boolean(),
     unescaped_jsonp = false             :: boolean(),

--- a/src/jsx_parser.erl
+++ b/src/jsx_parser.erl
@@ -109,6 +109,8 @@ value([Number|Tokens], Handler, Stack, Config) when is_float(Number) ->
     maybe_done(Tokens, handle_event({float, Number}, Handler, Config), Stack, Config);
 value([{raw, Raw}|Tokens], Handler, Stack, Config) when is_binary(Raw) ->
     value((jsx:decoder(?MODULE, [], []))(Raw) ++ Tokens, Handler, Stack, Config);
+value([{S,_,_}=Decimal|Tokens], Handler, Stack, Config) when S == 0; S == 1 ->
+    maybe_done(Tokens, handle_event({decimal, Decimal}, Handler, Config), Stack, Config);
 value([{_,_,_}=Timestamp|Tokens], Handler, Stack, Config) ->
   {{Year, Month, Day}, {Hour, Min, Sec}} = calendar:now_to_datetime(
                                                    Timestamp),

--- a/src/jsx_to_json.erl
+++ b/src/jsx_to_json.erl
@@ -118,7 +118,9 @@ encode(literal, Literal, _Config) ->
 encode(integer, Integer, _Config) ->
     erlang:integer_to_list(Integer);
 encode(float, Float, _Config) ->
-    io_lib:format("~p", [Float]).
+    io_lib:format("~p", [Float]);
+encode(decimal, Decimal, _Config) ->
+    re:replace(decimal_conv:string(Decimal), "E\\+?", "e").
 
 
 space(Config) ->


### PR DESCRIPTION
1> jsx:encode(#{foo=>{0,314,-2}}).
<<"{\"foo\":3.14}">>
2> jsx:decode(jsx:encode(#{foo=>{0,314,-2}})).
[{<<"foo">>,3.14}]
3> jsx:decode(jsx:encode(#{foo=>{0,314,-2}}),[decimal]).
[{<<"foo">>,{0,314,-2}}]